### PR TITLE
feat(backup): support runNow trigger for one-time and scheduled backups

### DIFF
--- a/snaptrack-backend/internal/models/backup.go
+++ b/snaptrack-backend/internal/models/backup.go
@@ -56,6 +56,7 @@ type BackupLog struct {
 	Status    string             `json:"status" bson:"status"`     // e.g., "started", "executed", "completed", "failed"
 	Message   string             `json:"message" bson:"message"`   // Log message or error details
 	CreatedAt time.Time          `json:"createdAt" bson:"createdAt"`
+
 }
 
 // Backup model
@@ -71,5 +72,6 @@ type Backup struct {
 	Schedule        Schedule           `json:"schedule" bson:"schedule"`
 	NextRun         time.Time          `json:"nextRun,omitempty" bson:"nextRun,omitempty"`
 	Logs            []BackupLog        `json:"logs,omitempty" bson:"logs,omitempty"`
+	RunNow          bool               `json:"runNow" bson:"runNow"`
 	CreatedAt       time.Time          `json:"createdAt" bson:"createdAt"`
 }


### PR DESCRIPTION
- Enhanced CreateBackup API to support immediate execution using runNow flag
- Allows backups with any scheduleKind (e.g., hourly, daily) to run instantly if runNow is true
- Added validation logic to bypass schedule.date check when runNow is true
- Triggers ExecuteBackup() in background goroutine when runNow is set
- Ensures proper logging of immediate backup trigger events